### PR TITLE
add new test case to commit-proof-fixtures.json

### DIFF
--- a/firehose/commit-proof-fixtures.json
+++ b/firehose/commit-proof-fixtures.json
@@ -92,5 +92,27 @@
       "bafyreihlhqn4quwcgbum5g4wzkini2c42j7zi5dsjdgkzm55jxyvebndue",
       "bafyreiggcbzkb2wgenvyfhkh2nggf7pohb7uzjm6bs7hixhjxw2xpmnq6u"
     ]
+  },
+  {
+    "comment": "split with earlier leaves on same layer",
+    "leafValue": "bafyreie5cvv4h45feadgeuwhbcutmh6t2ceseocckahdoe6uat64zmz454",
+    "keys": [
+      "app.bsky.feed.post/3lo3kqqljmfe2",
+      "app.bsky.feed.post/3log4547dm6h2",
+      "app.bsky.feed.post/3log45inogon2",
+      "app.bsky.feed.post/3logaodrh74d2",
+      "app.bsky.feed.post/3logteazog2n2",
+      "app.bsky.feed.post/3lon5cqsbwrj2",
+      "app.bsky.feed.repost/3l6sjhvqonco2"
+    ],
+    "adds": ["app.bsky.feed.post/3lon5dzeaihj2"],
+    "dels": [],
+    "rootBeforeCommit": "bafyreigfcsro2up7qi7l3rxdpg7n6gjtteotkmgrrqztl5oy2tf4ncl4ji",
+    "rootAfterCommit": "bafyreig33hsjiplaixvmccy65n7rn3in5nsbtcittzx6k3w5wjfhk2sg3a",
+    "blocksInProof": [
+      "bafyreig33hsjiplaixvmccy65n7rn3in5nsbtcittzx6k3w5wjfhk2sg3a",
+      "bafyreih2rhjm3apcghihwfojv2em7noqkgt5qyjcnxux7do674m464oc3m",
+      "bafyreiajhswkduap4zvqvfhth3skdgckmk2eb5gow7vv3gvj45f4fqwmxm"
+    ]
   }
 ]


### PR DESCRIPTION
my first pass at a sync v1.1 inductive firehose implementation passed all the existing test cases, but `goat --verify-mst` still occasionally complained `err: failed to invert op: partial MST, can't determine insertion order`. finally tracked it down to snarfed/arroba@8ef584e77ff5f00448fb3d2ccd2c4108fa6e8a26, which I minimized (ish) to this test case.

hope you don't mind the collections and rkeys, I didn't go to the extra effort of making up test paths with the same set of layers. hopefully they're relatively innocuous without the DID.