### PR TITLE
add https://example.com] to syntax/uri_syntax_invalid.txt

### DIFF
--- a/syntax/uri_syntax_invalid.txt
+++ b/syntax/uri_syntax_invalid.txt
@@ -11,6 +11,7 @@ http:
 https://example.com/path gap
   https://example.com/path
 https://example.com/trailing-whitespace  
+https://example.com]
 
 # too long (max 8 kbytes)
 # python: "https://example.com/" + 8200 *"x"


### PR DESCRIPTION
Python 3.12's urllib.parse.urlparse raises ValueError: Invalid IPv6 URL on this